### PR TITLE
fix: Remove $schema URL that triggers impersonation validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "n-skills",
   "description": "Curated plugin marketplace for AI agents - works with Claude Code, Codex, and openskills",
   "owner": {
@@ -36,7 +35,7 @@
     }
   ],
   "metadata": {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "generated_at": "2026-01-02T23:50:00.000Z",
     "skill_count": 3
   }


### PR DESCRIPTION
## Summary
- Removed the `$schema` field from `marketplace.json` that referenced `https://anthropic.com/claude-code/marketplace.schema.json`
- This fake URL triggers Claude Code's security validation which rejects marketplaces that appear to impersonate official Anthropic sources

## Problem
When trying to install plugins from this marketplace:
```
/plugin install gastown@numman-ali/n-skills
```

Users get:
```
Invalid schema: name: Marketplace name cannot impersonate official Anthropic/Claude marketplaces. 
Names containing "official", "anthropic", or "claude" in official-sounding combinations are reserved.
```

## Fix
Removed the `$schema` line entirely. The schema URL was non-functional anyway (the URL doesn't exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)