### PR TITLE
fix: Remove $schema from update-registry.mjs generator

### DIFF
--- a/scripts/update-registry.mjs
+++ b/scripts/update-registry.mjs
@@ -52,7 +52,6 @@ for (const skill of sources.skills || []) {
 console.log("📦 Updating marketplace.json...");
 
 const marketplace = {
-  $schema: "https://anthropic.com/claude-code/marketplace.schema.json",
   name: "n-skills",
   description:
     "Curated plugin marketplace for AI agents - works with Claude Code, Codex, and openskills",


### PR DESCRIPTION
## Summary
- Removed the `$schema` field from the `update-registry.mjs` script that generates `marketplace.json`

## Problem
PR #1 fixed `marketplace.json` directly, but the `update-registry.mjs` script regenerates that file and was re-adding the problematic `anthropic.com` URL on every run.

This is why the install still fails:
```
/plugin install gastown@numman-ali/n-skills
Invalid schema: name: Marketplace name cannot impersonate official Anthropic/Claude marketplaces.
```

## Fix
Removed the `$schema` line from the generator script so future regenerations won't break installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)