### PR TITLE
fix: correct marketplace.json structure and add missing plugin.json files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,21 +7,49 @@
   },
   "plugins": [
     {
-      "name": "n-skills",
-      "description": "Curated collection of high-quality skills for AI coding agents. Includes browser automation, multi-agent orchestration, vision/search tools, and workflow coordination.",
-      "source": "./",
-      "skills": [
-        "./skills/tools/zai-cli",
-        "./skills/tools/gastown",
-        "./skills/automation/dev-browser",
-        "./skills/workflow/orchestration"
-      ],
-      "strict": false
+      "name": "zai-cli",
+      "description": "Z.AI vision, search, reader, and GitHub exploration via MCP",
+      "source": "./skills/tools/zai-cli",
+      "category": "tools",
+      "author": {
+        "name": "Numman Ali",
+        "github": "numman-ali"
+      }
+    },
+    {
+      "name": "gastown",
+      "description": "Multi-agent orchestrator for Claude Code. Use when user mentions gastown, gas town, gt commands, convoys, polecats, rigs, slinging work, multi-agent coordination.",
+      "source": "./skills/tools/gastown",
+      "category": "tools",
+      "author": {
+        "name": "Numman Ali",
+        "github": "numman-ali"
+      }
+    },
+    {
+      "name": "dev-browser",
+      "description": "Browser automation with persistent page state. Use when users ask to navigate websites, fill forms, take screenshots, extract web data, test web apps, or automate browser workflows.",
+      "source": "./skills/automation/dev-browser",
+      "category": "automation",
+      "author": {
+        "name": "Sawyer Hood",
+        "github": "SawyerHood"
+      }
+    },
+    {
+      "name": "orchestration",
+      "description": "Multi-agent orchestration for complex tasks using cc-mirror tasks and TodoWrite. Use when tasks require parallel work, multiple agents, sophisticated coordination, or decomposition into parallel subtasks.",
+      "source": "./skills/workflow/orchestration",
+      "category": "workflow",
+      "author": {
+        "name": "Numman Ali",
+        "github": "numman-ali"
+      }
     }
   ],
   "metadata": {
-    "version": "1.2.0",
-    "generated_at": "2026-01-08T12:00:00.000Z",
+    "version": "1.2.1",
+    "generated_at": "2026-01-09T21:15:00.000Z",
     "skill_count": 4
   }
 }

--- a/skills/automation/dev-browser/.claude-plugin/plugin.json
+++ b/skills/automation/dev-browser/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "dev-browser",
+  "description": "Browser automation with persistent page state. Use when users ask to navigate websites, fill forms, take screenshots, extract web data, test web apps, or automate browser workflows.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Sawyer Hood",
+    "url": "https://github.com/SawyerHood"
+  },
+  "repository": "https://github.com/SawyerHood/dev-browser",
+  "license": "MIT",
+  "homepage": "https://github.com/SawyerHood/dev-browser",
+  "keywords": [
+    "browser",
+    "automation",
+    "playwright",
+    "screenshots"
+  ]
+}

--- a/skills/tools/gastown/.claude-plugin/plugin.json
+++ b/skills/tools/gastown/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "gastown",
+  "description": "Multi-agent orchestrator for Claude Code. Use when user mentions gastown, gas town, gt commands, convoys, polecats, rigs, slinging work, multi-agent coordination.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Numman Ali",
+    "url": "https://github.com/numman-ali"
+  },
+  "repository": "https://github.com/steveyegge/gastown",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/steveyegge/gastown",
+  "keywords": [
+    "multi-agent",
+    "orchestration",
+    "coordination"
+  ]
+}

--- a/skills/tools/zai-cli/.claude-plugin/plugin.json
+++ b/skills/tools/zai-cli/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "zai-cli",
+  "description": "Z.AI vision, search, reader, and GitHub exploration via MCP",
+  "version": "1.0.0",
+  "author": {
+    "name": "Numman Ali",
+    "url": "https://github.com/numman-ali"
+  },
+  "repository": "https://github.com/numman-ali/zai-cli",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/numman-ali/zai-cli",
+  "keywords": [
+    "vision",
+    "search",
+    "github",
+    "mcp"
+  ]
+}

--- a/skills/workflow/orchestration/.claude-plugin/plugin.json
+++ b/skills/workflow/orchestration/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "orchestration",
+  "description": "Multi-agent orchestration for complex tasks using cc-mirror tasks and TodoWrite. Use when tasks require parallel work, multiple agents, sophisticated coordination, or decomposition into parallel subtasks.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Numman Ali",
+    "url": "https://github.com/numman-ali"
+  },
+  "repository": "https://github.com/numman-ali/n-skills",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/numman-ali/n-skills",
+  "keywords": [
+    "orchestration",
+    "multi-agent",
+    "parallel-tasks",
+    "workflow"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR fixes two issues that prevent skills from being installed via `/plugin install <skill>@n-skills` in Claude Code.

**Problem:** When running `/plugin marketplace add numman-ali/n-skills` followed by `/plugin install orchestration@n-skills`, the error `Plugin "orchestration" not found in any marketplace` is returned.

## Root Causes

### Issue 1: Malformed marketplace.json structure

The Claude Code plugin system expects each installable plugin to be a **separate entry** in the `plugins` array with its own `name` and `source` fields. The previous structure had a single plugin entry named `"n-skills"` with a nested `skills` array:

<details>
<summary>Before (broken)</summary>

```json
{
  "plugins": [
    {
      "name": "n-skills",
      "description": "Curated collection...",
      "source": "./",
      "skills": [
        "./skills/tools/zai-cli",
        "./skills/tools/gastown",
        "./skills/automation/dev-browser",
        "./skills/workflow/orchestration"
      ],
      "strict": false
    }
  ]
}
```
</details>

<details>
<summary>After (fixed)</summary>

```json
{
  "plugins": [
    {
      "name": "zai-cli",
      "description": "Z.AI vision, search, reader...",
      "source": "./skills/tools/zai-cli",
      "category": "tools",
      "author": { "name": "Numman Ali", "github": "numman-ali" }
    },
    {
      "name": "gastown",
      "source": "./skills/tools/gastown",
      ...
    },
    {
      "name": "dev-browser",
      "source": "./skills/automation/dev-browser",
      ...
    },
    {
      "name": "orchestration",
      "source": "./skills/workflow/orchestration",
      ...
    }
  ]
}
```
</details>

This mirrors the structure used in [claude-plugins-official](https://github.com/anthropics/claude-plugins-official/blob/main/.claude-plugin/marketplace.json).

### Issue 2: Missing `.claude-plugin/plugin.json` files

Each skill needs a `.claude-plugin/plugin.json` manifest file for the plugin system to recognize it as installable. The skills only had `SKILL.md` files but no plugin manifests.

**Files added:**
- `skills/tools/zai-cli/.claude-plugin/plugin.json`
- `skills/tools/gastown/.claude-plugin/plugin.json`
- `skills/automation/dev-browser/.claude-plugin/plugin.json`
- `skills/workflow/orchestration/.claude-plugin/plugin.json`

## How I Found This

I compared the n-skills marketplace structure against:
1. `~/.claude/plugins/marketplaces/beads-marketplace/.claude-plugin/` (working plugin)
2. `~/.claude/plugins/marketplaces/claude-plugins-official/.claude-plugin/marketplace.json` (reference)

The beads plugin has both a proper `marketplace.json` structure AND individual `plugin.json` files in each plugin directory.

## Testing

After these changes:
```
❯ /plugin install orchestration@n-skills
  ⎿  Successfully installed orchestration@n-skills
```

## Changes

| File | Change |
|------|--------|
| `.claude-plugin/marketplace.json` | Restructured plugins array to list each skill individually |
| `skills/tools/zai-cli/.claude-plugin/plugin.json` | **New** - Plugin manifest |
| `skills/tools/gastown/.claude-plugin/plugin.json` | **New** - Plugin manifest |
| `skills/automation/dev-browser/.claude-plugin/plugin.json` | **New** - Plugin manifest |
| `skills/workflow/orchestration/.claude-plugin/plugin.json` | **New** - Plugin manifest |

## Notes for Maintainer

- The `sources.yaml` file is excellent for tracking skill provenance but isn't read by the Claude Code plugin system - only `marketplace.json` is
- Consider adding a build script to auto-generate `marketplace.json` from `sources.yaml` to keep them in sync
- Each plugin.json includes metadata pulled from the corresponding `sources.yaml` entry

---

🤖 Generated with [Claude Code](https://claude.ai/code)