### PR TITLE
fix(security): pin yaml devDependency to exact version 2.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "homepage": "https://github.com/numman-ali/n-skills#readme",
   "devDependencies": {
-    "yaml": "^2.8.3"
+    "yaml": "2.8.3"
   }
 }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`package.json` declares the `yaml` devDependency with a caret range:

```json
"yaml": "^2.8.3"
```

A caret range allows npm to automatically install any compatible minor or patch release (e.g. `2.9.0`, `2.8.4`). In CI environments, this means the installed version can silently change between runs whenever a new release is published — without any code change in this repo.

Since `yaml` is used to parse `sources.yaml`, which controls which external repos are cloned by the sync workflow, an unexpected version bump in the parser could introduce behavioral changes or vulnerabilities without review.

## Fix

Pin to the exact version that was audited:

```json
"yaml": "2.8.3"
```

This is a one-line change with no functional impact for the current version. Future upgrades remain intentional and visible in the diff.

## Why it matters

Supply-chain hygiene for CI scripts: unpinned deps in a workflow that clones third-party repos and writes files to the repo are a meaningful attack surface. Pinning is low-cost and eliminates one category of silent drift.