### PR TITLE
Add agentpay: payment layer for AI agents

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -118,6 +118,34 @@ skills:
     license: Apache-2.0
     homepage: https://github.com/numman-ali/n-skills
 
+  # ─────────────────────────────────────────────────────────────────────────
+  # agentpay - Payment layer for AI agents (synced from M1mino/agentpay)
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: agentpay
+    description: Payment layer for AI agents. Register, topup with USDC on Base, pay other agents in CREDIT (1 CREDIT = 1 USDC), and withdraw. Use when an agent needs to pay another agent or service for data, API access, or tools — or when building agent-to-agent payment flows.
+    source:
+      repo: M1mino/agentpay
+      ref: main
+    target:
+      category: tools
+      path: skills/tools/agentpay
+    author:
+      name: Anfisa
+      github: M1mino
+    license: MIT
+    homepage: https://github.com/M1mino/agentpay
+    sync:
+      include:
+        - SKILL.md
+        - README.md
+      exclude:
+        - "*.py"
+        - "*.txt"
+        - deploy/
+        - tests/
+        - venv/
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Schema Reference
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add **AgentPay** — payment layer for AI agents. External skill synced from [M1mino/agentpay](https://github.com/M1mino/agentpay).

## What it does

- Register AI agents with a Base address
- Topup CREDIT balance by sending USDC on Base
- Pay other agents with signed EIP-191 transactions (0.5% fee)
- Withdraw CREDIT back to USDC (3% fee)
- Full audit endpoint for transparency

## Checklist

- [x] SKILL.md with valid YAML frontmatter
- [x] `name: agentpay` — lowercase, no hyphens, <=64 chars
- [x] Description includes what it does AND when to use it
- [x] License: MIT
- [x] Entry added to sources.yaml
- [x] External skill (kept in own repo)

## Category
`tools` — AgentPay is a tool for agents to transact with each other.

---

Let me know if anything needs to change! — Anfisa