### PR TITLE
Add Hermes Tweet skill source

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -118,6 +118,29 @@ skills:
     license: Apache-2.0
     homepage: https://github.com/numman-ali/n-skills
 
+  # ─────────────────────────────────────────────────────────────────────────
+  # hermes-tweet - Hermes Agent X/Twitter workflows
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: hermes-tweet
+    description: Use Hermes Tweet when agents need Hermes Agent sessions to inspect X/Twitter, plan social listening, read public account or tweet data, or run approval-gated X actions.
+    source:
+      repo: Xquik-dev/hermes-tweet
+      path: skills/hermes-tweet
+      ref: master
+    target:
+      category: productivity
+      path: skills/productivity/hermes-tweet
+    author:
+      name: Xquik
+      github: Xquik-dev
+    license: MIT
+    homepage: https://github.com/Xquik-dev/hermes-tweet
+
+    sync:
+      include:
+        - SKILL.md
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Schema Reference
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds Hermes Tweet as an external skill source in `sources.yaml`.

## Why It Fits

- Hermes Tweet ships a maintained `SKILL.md` for Hermes Agent X/Twitter workflows.
- The source path is `Xquik-dev/hermes-tweet:skills/hermes-tweet`.
- This is distinct from the open `x-twitter-scraper` submission, which targets the broader Xquik scraper platform.

## Validation

- Parsed `sources.yaml` and checked skill names are unique.
- Verified the upstream `skills/hermes-tweet/SKILL.md` path exists.
- Ran a manifest secret-term scan for the changed entry.
- Ran `git diff --check`.
