### PR TITLE
Add Agent Safety Preflight external skill source

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -149,3 +149,16 @@ skills:
 #   sync:          Optional. Fine-grained sync control
 #     include:     List of files/folders to copy
 #     exclude:     Glob patterns to skip
+- name: agent-safety-preflight
+  source:
+    repo: el-zachariah/ai-agent-safety-starter-pack
+    path: skills/agent-safety-preflight
+    ref: main
+  target:
+    category: development
+    path: skills/development/agent-safety-preflight
+  author:
+    name: Signal Loom Works
+    github: el-zachariah
+  license: MIT
+  homepage: https://github.com/el-zachariah/ai-agent-safety-starter-pack


### PR DESCRIPTION
## Summary
- Recovers this PR from a copied skill-folder submission to the `n-skills` preferred external-source route.
- Adds `agent-safety-preflight` to `sources.yaml`, pointing at `el-zachariah/ai-agent-safety-starter-pack` / `skills/agent-safety-preflight`.
- Keeps ownership/source maintenance in the public free repo and targets `skills/development/agent-safety-preflight`.

## Verification
- Raw commit-pinned `sources.yaml` marker check passed for name, source repo/path, target path, author, license, and homepage.
- Raw proof: https://raw.githubusercontent.com/el-zachariah/n-skills/28964f063ae14f711460854ee28f08808d823572/sources.yaml
