### PR TITLE
feat: add Atlas Cloud image generation skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,6 +17,16 @@
       }
     },
     {
+      "name": "atlas-cloud-image",
+      "description": "Generate images through Atlas Cloud with live model and input-schema validation. Use when the user asks to create an image with Atlas Cloud or needs an optional API-based text-to-image provider.",
+      "source": "./skills/tools/atlas-cloud-image",
+      "category": "tools",
+      "author": {
+        "name": "binyangzhu000-sudo",
+        "github": "binyangzhu000-sudo"
+      }
+    },
+    {
       "name": "gastown",
       "description": "Multi-agent orchestrator for Claude Code. Use when user mentions gastown, gas town, gt commands, convoys, polecats, rigs, slinging work, multi-agent coordination.",
       "source": "./skills/tools/gastown",
@@ -59,7 +69,7 @@
   ],
   "metadata": {
     "version": "1.3.5",
-    "generated_at": "2026-07-16T00:31:46.168Z",
-    "skill_count": 5
+    "generated_at": "2026-08-27T13:01:43.358Z",
+    "skill_count": 6
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,13 @@ Invoke skills using: `openskills read <skill-name>`
 </skill>
 
 <skill>
+<name>atlas-cloud-image</name>
+<description>Generate images through Atlas Cloud with live model and input-schema validation. Use when the user asks to create an image with Atlas Cloud or needs an optional API-based text-to-image provider.</description>
+<location>skills/tools/atlas-cloud-image</location>
+<invoke>openskills read atlas-cloud-image</invoke>
+</skill>
+
+<skill>
 <name>dev-browser</name>
 <description>Browser automation with persistent page state. Use when users ask to navigate websites, fill forms, take screenshots, extract web data, test web apps, or automate browser workflows.</description>
 <location>skills/automation/dev-browser</location>
@@ -62,6 +69,7 @@ Invoke skills using: `openskills read <skill-name>`
 
 ### tools
 - **zai-cli**: Z.AI vision, search, reader, and GitHub exploration via MCP
+- **atlas-cloud-image**: Generate images through Atlas Cloud with live model and input-schema validation
 - **gastown**: Multi-agent orchestrator for Claude Code
 
 ### automation

--- a/skills/tools/atlas-cloud-image/.claude-plugin/plugin.json
+++ b/skills/tools/atlas-cloud-image/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "atlas-cloud-image",
+  "description": "Generate images with Atlas Cloud using live model and schema discovery",
+  "version": "1.0.0",
+  "author": {
+    "name": "binyangzhu000-sudo",
+    "url": "https://github.com/binyangzhu000-sudo"
+  },
+  "repository": "https://github.com/numman-ali/n-skills",
+  "license": "Apache-2.0",
+  "homepage": "https://www.atlascloud.ai",
+  "keywords": ["atlas-cloud", "image-generation", "text-to-image"]
+}

--- a/skills/tools/atlas-cloud-image/skills/atlas-cloud-image/SKILL.md
+++ b/skills/tools/atlas-cloud-image/skills/atlas-cloud-image/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: atlas-cloud-image
+description: Generate images through Atlas Cloud with live model and input-schema validation. Use when the user asks to create an image with Atlas Cloud or needs an optional API-based text-to-image provider.
+license: Apache-2.0
+compatibility: Python 3.10+ with network access
+metadata:
+  author: binyangzhu000-sudo
+  version: "1.0.0"
+---
+
+# Atlas Cloud Image
+
+Use Atlas Cloud as an optional image-generation provider. Keep an application's
+existing provider and defaults unchanged unless the user explicitly requests a
+switch.
+
+## Setup
+
+Set the API key in the environment. Never pass it as a command-line argument or
+write it to project files.
+
+```bash
+export ATLASCLOUD_API_KEY="..."
+```
+
+## Discover a Model
+
+Always query the live catalog before generation. The helper lists only visible
+image models:
+
+```bash
+python3 {baseDir}/scripts/generate.py list --search image
+```
+
+Choose an exact model ID from that output. The helper then downloads the model's
+current OpenAPI schema and rejects unsupported input fields or enum values.
+
+## Generate
+
+```bash
+python3 {baseDir}/scripts/generate.py generate \
+  --model "MODEL_ID_FROM_LIST" \
+  --prompt "A clean product launch image with one focal point" \
+  --size 1024x1024 \
+  --output launch.png
+```
+
+Optional `--quality` and `--output-format` values must be supported by the live
+schema. Without `--output`, the helper prints the generated media URL.
+
+## Operational Rules
+
+1. Fetch the live catalog and selected model schema for every generation.
+2. Submit the billable generation POST exactly once; never retry it automatically.
+3. Retry only transient prediction GET failures, within the configured poll limit.
+4. Treat failed or canceled predictions as terminal.
+5. Keep credentials in environment variables and out of logs and commits.

--- a/skills/tools/atlas-cloud-image/skills/atlas-cloud-image/scripts/generate.py
+++ b/skills/tools/atlas-cloud-image/skills/atlas-cloud-image/scripts/generate.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Discover Atlas Cloud image models and submit one image generation job."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_BASE_URL = "https://api.atlascloud.ai"
+
+
+class AtlasError(RuntimeError):
+    def __init__(self, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+
+
+def request_json(
+    method: str,
+    url: str,
+    *,
+    api_key: str | None = None,
+    payload: dict[str, Any] | None = None,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "atlas-cloud-image-skill/1.0",
+    }
+    data = None
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(payload).encode("utf-8")
+
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise AtlasError(
+            f"Atlas HTTP {exc.code}: {detail}",
+            retryable=exc.code == 429 or exc.code >= 500,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise AtlasError(f"Atlas request failed: {exc.reason}", retryable=True) from exc
+
+    try:
+        result = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise AtlasError("Atlas returned invalid JSON") from exc
+    if not isinstance(result, dict):
+        raise AtlasError("Atlas returned an unexpected response shape")
+    return result
+
+
+def unwrap(payload: dict[str, Any]) -> dict[str, Any]:
+    code = payload.get("code")
+    if code is not None and str(code) not in {"0", "200"}:
+        raise AtlasError(str(payload.get("message") or f"Atlas API error {code}"))
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise AtlasError("Atlas response data is not an object")
+    return data
+
+
+def fetch_models(base_url: str) -> list[dict[str, Any]]:
+    payload = request_json("GET", f"{base_url}/api/v1/models")
+    code = payload.get("code")
+    if code is not None and str(code) not in {"0", "200"}:
+        raise AtlasError(str(payload.get("message") or f"Atlas API error {code}"))
+    models = payload.get("data")
+    if not isinstance(models, list):
+        raise AtlasError("Atlas model catalog is not a list")
+    return [model for model in models if isinstance(model, dict)]
+
+
+def visible_image_models(models: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        model
+        for model in models
+        if (model.get("display_console") is True or model.get("displayConsole") is True)
+        and str(model.get("type", "")).lower() == "image"
+    ]
+
+
+def find_model(models: list[dict[str, Any]], model_id: str) -> dict[str, Any]:
+    for model in visible_image_models(models):
+        if model.get("model") == model_id:
+            return model
+    raise AtlasError(f"Model is not a visible Atlas image model: {model_id}")
+
+
+def fetch_input_schema(model: dict[str, Any]) -> dict[str, Any]:
+    schema_url = model.get("schema")
+    if not isinstance(schema_url, str) or not schema_url.startswith("https://"):
+        raise AtlasError("Selected model does not expose an HTTPS schema URL")
+    document = request_json("GET", schema_url)
+    try:
+        schema = document["components"]["schemas"]["Input"]
+    except (KeyError, TypeError) as exc:
+        raise AtlasError("Selected model schema has no components.schemas.Input") from exc
+    if not isinstance(schema, dict):
+        raise AtlasError("Selected model input schema is invalid")
+    return schema
+
+
+def build_payload(args: argparse.Namespace, schema: dict[str, Any]) -> dict[str, Any]:
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict) or "prompt" not in properties:
+        raise AtlasError("Selected model schema does not support prompt")
+
+    payload: dict[str, Any] = {"model": args.model, "prompt": args.prompt}
+    for name, value in {
+        "size": args.size,
+        "quality": args.quality,
+        "output_format": args.output_format,
+    }.items():
+        if value is None:
+            continue
+        if name not in properties:
+            raise AtlasError(f"Selected model schema does not support {name}")
+        allowed = properties[name].get("enum")
+        if isinstance(allowed, list) and value not in allowed:
+            raise AtlasError(f"Invalid {name}: {value}. Allowed: {', '.join(map(str, allowed))}")
+        payload[name] = value
+    if "enable_sync_mode" in properties:
+        payload["enable_sync_mode"] = False
+    if "enable_base64_output" in properties:
+        payload["enable_base64_output"] = False
+    return payload
+
+
+def submit_generation(base_url: str, api_key: str, payload: dict[str, Any]) -> dict[str, Any]:
+    # Intentionally one POST only. A failed submission is never retried automatically.
+    return unwrap(
+        request_json(
+            "POST",
+            f"{base_url}/api/v1/model/generateImage",
+            api_key=api_key,
+            payload=payload,
+            timeout=60,
+        )
+    )
+
+
+def poll_generation(
+    base_url: str,
+    api_key: str,
+    prediction_id: str,
+    *,
+    attempts: int,
+    interval: float,
+) -> dict[str, Any]:
+    for attempt in range(attempts):
+        try:
+            prediction = unwrap(
+                request_json(
+                    "GET",
+                    f"{base_url}/api/v1/model/result/{prediction_id}",
+                    api_key=api_key,
+                )
+            )
+        except AtlasError as exc:
+            if not exc.retryable or attempt + 1 >= attempts:
+                raise
+            time.sleep(min(interval * (2**attempt), 8))
+            continue
+
+        status = str(prediction.get("status", "")).lower()
+        if status in {"completed", "succeeded"}:
+            return prediction
+        if status in {"failed", "canceled", "cancelled"}:
+            raise AtlasError(str(prediction.get("error") or f"Prediction {status}"))
+        if attempt + 1 < attempts:
+            time.sleep(interval)
+    raise AtlasError(f"Prediction did not complete after {attempts} polls")
+
+
+def extract_output_url(prediction: dict[str, Any]) -> str:
+    outputs = prediction.get("outputs")
+    if isinstance(outputs, list) and outputs and isinstance(outputs[0], str):
+        return outputs[0]
+    output = prediction.get("output")
+    if isinstance(output, str):
+        return output
+    raise AtlasError("Completed prediction has no output URL")
+
+
+def download(url: str, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with urllib.request.urlopen(url, timeout=60) as response:
+            output.write_bytes(response.read())
+    except urllib.error.URLError as exc:
+        raise AtlasError(f"Could not download generated image: {exc.reason}") from exc
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("ATLASCLOUD_BASE_URL", DEFAULT_BASE_URL),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    list_parser = subparsers.add_parser("list", help="List current visible image models")
+    list_parser.add_argument("--search", default="")
+
+    generate = subparsers.add_parser("generate", help="Generate one image")
+    generate.add_argument("--model", required=True)
+    generate.add_argument("--prompt", required=True)
+    generate.add_argument("--size")
+    generate.add_argument("--quality")
+    generate.add_argument("--output-format")
+    generate.add_argument("--output", type=Path)
+    generate.add_argument("--poll-attempts", type=int, default=100)
+    generate.add_argument("--poll-interval", type=float, default=3)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    base_url = args.base_url.rstrip("/")
+    try:
+        models = fetch_models(base_url)
+        if args.command == "list":
+            query = args.search.lower()
+            for model in visible_image_models(models):
+                model_id = str(model.get("model", ""))
+                display_name = str(model.get("displayName", ""))
+                if not query or query in f"{model_id} {display_name}".lower():
+                    print(f"{model_id}\t{display_name}")
+            return 0
+
+        if args.poll_attempts < 1 or args.poll_interval < 0:
+            raise AtlasError("Polling limits must be positive")
+        api_key = os.environ.get("ATLASCLOUD_API_KEY")
+        if not api_key:
+            raise AtlasError("ATLASCLOUD_API_KEY is required for generation")
+
+        model = find_model(models, args.model)
+        payload = build_payload(args, fetch_input_schema(model))
+        prediction = submit_generation(base_url, api_key, payload)
+        if str(prediction.get("status", "")).lower() not in {"completed", "succeeded"}:
+            prediction_id = prediction.get("id")
+            if not isinstance(prediction_id, str) or not prediction_id:
+                raise AtlasError("Generation response has no prediction ID")
+            prediction = poll_generation(
+                base_url,
+                api_key,
+                prediction_id,
+                attempts=args.poll_attempts,
+                interval=args.poll_interval,
+            )
+
+        output_url = extract_output_url(prediction)
+        if args.output:
+            download(output_url, args.output)
+            print(args.output)
+        else:
+            print(output_url)
+        return 0
+    except AtlasError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/tools/atlas-cloud-image/skills/atlas-cloud-image/tests/test_generate.py
+++ b/skills/tools/atlas-cloud-image/skills/atlas-cloud-image/tests/test_generate.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).parents[1] / "scripts" / "generate.py"
+SPEC = importlib.util.spec_from_file_location("atlas_generate", MODULE_PATH)
+assert SPEC and SPEC.loader
+atlas_generate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(atlas_generate)
+
+
+class GenerateTest(unittest.TestCase):
+    def test_visible_image_models_excludes_hidden_and_video(self) -> None:
+        models = [
+            {"model": "visible", "type": "Image", "display_console": True},
+            {"model": "hidden", "type": "Image", "display_console": False},
+            {"model": "video", "type": "Video", "display_console": True},
+        ]
+        self.assertEqual(
+            ["visible"],
+            [model["model"] for model in atlas_generate.visible_image_models(models)],
+        )
+
+    def test_build_payload_uses_schema_supported_values(self) -> None:
+        args = argparse.Namespace(
+            model="provider/model",
+            prompt="A launch image",
+            size="1024x1024",
+            quality="high",
+            output_format="png",
+        )
+        schema = {
+            "properties": {
+                "prompt": {"type": "string"},
+                "size": {"enum": ["1024x1024"]},
+                "quality": {"enum": ["medium", "high"]},
+                "output_format": {"enum": ["jpeg", "png"]},
+                "enable_sync_mode": {"type": "boolean"},
+            }
+        }
+        self.assertEqual(
+            {
+                "model": "provider/model",
+                "prompt": "A launch image",
+                "size": "1024x1024",
+                "quality": "high",
+                "output_format": "png",
+                "enable_sync_mode": False,
+            },
+            atlas_generate.build_payload(args, schema),
+        )
+
+    def test_submit_generation_posts_once(self) -> None:
+        with patch.object(
+            atlas_generate,
+            "request_json",
+            return_value={"code": 200, "data": {"id": "prediction-1", "status": "starting"}},
+        ) as request:
+            result = atlas_generate.submit_generation(
+                "https://example.test", "secret", {"prompt": "x"}
+            )
+        self.assertEqual("prediction-1", result["id"])
+        self.assertEqual(1, request.call_count)
+        self.assertEqual("POST", request.call_args.args[0])
+
+    def test_polling_is_bounded(self) -> None:
+        responses = [
+            {"code": 200, "data": {"status": "processing"}},
+            {"code": 200, "data": {"status": "completed", "outputs": ["https://cdn/image.png"]}},
+        ]
+        with (
+            patch.object(atlas_generate, "request_json", side_effect=responses) as request,
+            patch.object(atlas_generate.time, "sleep"),
+        ):
+            result = atlas_generate.poll_generation(
+                "https://example.test", "secret", "prediction-1", attempts=3, interval=0
+            )
+        self.assertEqual("completed", result["status"])
+        self.assertEqual(2, request.call_count)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sources.yaml
+++ b/sources.yaml
@@ -28,6 +28,19 @@ skills:
     license: Apache-2.0
     homepage: https://github.com/numman-ali/zai-cli
 
+  # atlas-cloud-image - Native optional image-generation provider
+  - name: atlas-cloud-image
+    description: Generate images through Atlas Cloud with live model and input-schema validation. Use when the user asks to create an image with Atlas Cloud or needs an optional API-based text-to-image provider.
+    native: true
+    target:
+      category: tools
+      path: skills/tools/atlas-cloud-image
+    author:
+      name: binyangzhu000-sudo
+      github: binyangzhu000-sudo
+    license: Apache-2.0
+    homepage: https://www.atlascloud.ai
+
   # ─────────────────────────────────────────────────────────────────────────
   # dev-browser - Browser automation (synced from SawyerHood/dev-browser)
   # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add a native `atlas-cloud-image` skill to the curated marketplace
- discover visible image models and validate options against the selected model's live schema
- submit image generation exactly once and use bounded polling only for result GETs
- include focused unit tests and register the skill in marketplace metadata

## Validation

- `python3 -m unittest discover -s skills/tools/atlas-cloud-image/skills/atlas-cloud-image/tests -p 'test_*.py' -v`
- `python3 -m py_compile skills/tools/atlas-cloud-image/skills/atlas-cloud-image/scripts/generate.py`
- `python3 skills/tools/atlas-cloud-image/skills/atlas-cloud-image/scripts/generate.py list --search gpt-image-2`
- source, frontmatter, plugin manifest, and marketplace consistency checks
- one real generation smoke produced a valid, nonblank 1024x1024 PNG
- `git diff --check`

`@agentskills/skills-ref` was also attempted as documented, but that package currently returns npm 404; the equivalent schema and registry checks were run locally. The implementation was prepared with AI assistance and manually reviewed and tested.
